### PR TITLE
feature: 정렬 모드 추가

### DIFF
--- a/Sources/HangulSearch/Source/Enum/SortMode.swift
+++ b/Sources/HangulSearch/Source/Enum/SortMode.swift
@@ -1,0 +1,15 @@
+//
+//  SortMode.swift
+//  
+//
+//  Created by 이주화 on 4/28/24.
+//
+
+import Foundation
+
+public enum SortMode {
+    case hangulOrder
+    case hangulOrderReversed
+    case editDistance
+    case none
+}

--- a/Sources/HangulSearch/Source/HangulSearch.swift
+++ b/Sources/HangulSearch/Source/HangulSearch.swift
@@ -25,6 +25,14 @@ public class HangulSearch<T> {
     /// - combined: 여러 검색 모드를 결합하여 검색을 수행
     private var searchMode: HangulSearchMode
     
+    /// 정렬 모드
+    /// - hangulOrder: 항목들을 한글 자모 순서대로 정렬.
+    /// - hangulOrderReversed: 항목들을 한글 자모 역순으로 정렬
+    /// - editDistance: 검색어와 항목 간의 편집 거리(레벤슈타인 거리)를 기준으로 항목을 정렬. 이 모드는
+    ///   검색어와 가장 유사한 항목을 우선적으로 보여주어 사용자가 관련성 높은 결과를 빠르게 인지할 수 있도록 합니다.
+    /// - none: 정렬을 수행하지 않습니다.
+    private var sortMode: SortMode
+    
     /// 초성 분해된 항목들
     /// - 각 항목의 키(key)는 초성으로 분해된 문자열입니다.
     private var processedItemsChosung: [(item: T, key: String)] = []
@@ -39,11 +47,13 @@ public class HangulSearch<T> {
     // MARK: Init
     /// - Parameters:
     ///   - items: 검색을 수행할 데이터의 배열
-    ///   - mode: 한글 검색 모드. 기본값은 chosungAndFullMatch
+    ///   - searchMode: 한글 검색 모드. 기본값은 chosungAndFullMatch
+    ///   - sortMode: 결과를 정렬하는 방식. 기본값은 .none
     ///   - keySelector: 각 항목에서 검색을 수행할 선택자를 선택하는 클로저
-    public init(items: [T], mode: HangulSearchMode = .chosungAndFullMatch, keySelector: @escaping (T) -> String) {
+    public init(items: [T], searchMode: HangulSearchMode = .chosungAndFullMatch, sortMode: SortMode = .none, keySelector: @escaping (T) -> String) {
         self.items = items
-        self.searchMode = mode
+        self.searchMode = searchMode
+        self.sortMode = sortMode
         self.keySelector = keySelector
         preprocessItems()
     }
@@ -57,20 +67,33 @@ public class HangulSearch<T> {
             return []
         }
         
+        var results: [T]
         // 검색 모드에 따라 적절한 검색 메서드를 선택하여 결과를 반환
         switch searchMode {
         case .containsMatch:
-            return searchByFullChar(input: input)
+            results = searchByFullChar(input: input)
         case .chosungAndFullMatch:
             // 검색어에 따라 어떤 검색을 수행할지 결정. 초성으로만 되어 있지 않으면, 일치하는 문자열 기반 검색 수행
-            return isPureChosung(input: input) ?
-            searchByChosung(input: input) :
-            searchByFullChar(input: input)
+            results = isPureChosung(input: input) ? searchByChosung(input: input) : searchByFullChar(input: input)
         case .autocomplete:
-            return searchByAutocomplete(input: input)
+            results = searchByAutocomplete(input: input)
         case .combined:
-            return searchByCombined(input: input)
+            results = searchByCombined(input: input)
         }
+        
+        // 정렬 로직 적용
+        switch sortMode {
+        case .hangulOrder:
+            results = sortItemsByHangulOrder(items: results)
+        case .hangulOrderReversed:
+            results = sortItemsByHangulOrderReversed(items: results)
+        case .editDistance:
+            results = sortItemsByEditDistance(to: input, items: results)
+        case .none:
+            break
+        }
+        
+        return results
     }
     
     /// 검색을 수행할 데이터를 변경, 변경된 항목에 대해 사전 처리를 수행
@@ -92,6 +115,12 @@ public class HangulSearch<T> {
     public func changeKeySelector(keySelector: @escaping (T) -> String) {
         self.keySelector = keySelector
         preprocessItems()
+    }
+    
+    /// 정렬 모드를 변경
+    /// - Parameter mode: 새로운 정렬 모드
+    public func changeSortMode(mode: SortMode) {
+        self.sortMode = mode
     }
 }
 
@@ -254,5 +283,69 @@ extension HangulSearch {
         let endUnicode: UInt32 = 0xD7A3
         return (unicode >= startUnicode) && (unicode <= endUnicode)
     }
-
+    
+    /// 항목들을 한글 자모 순서대로 정렬
+    /// - Parameter items: 정렬할 항목 배열
+    /// - Returns: 정렬된 항목 배열
+    private func sortItemsByHangulOrder(items: [T]) -> [T] {
+        return items.sorted { keySelector($0) < keySelector($1) }
+    }
+    
+    /// 항목들을 한글 자모 역순으로 정렬
+    /// - Parameter items: 정렬할 항목 배열
+    /// - Returns: 정렬된 항목 배열
+    private func sortItemsByHangulOrderReversed(items: [T]) -> [T] {
+        return items.sorted { keySelector($0) > keySelector($1) }
+    }
+    
+    /// 검색 입력에 대해 편집 거리를 기반으로 항목을 정렬
+    /// - Parameters:
+    ///   - target: 검색어
+    ///   - items: 정렬할 항목 배열
+    /// - Returns: 정렬된 항목 배열
+    private func sortItemsByEditDistance(to target: String, items: [T]) -> [T] {
+        return items.sorted {
+            levenshteinDistance(from: keySelector($0), to: target) < levenshteinDistance(from: keySelector($1), to: target)
+        }
+    }
+    
+    /// 레벤슈타인 편집 거리 계산 함수
+    /// 두 문자열 간의 레벤슈타인 편집 거리를 계산합니다.
+    /// 본 구현 방법에 대한 자세한 설명은 다음 웹사이트를 참고
+    /// https://lovit.github.io/nlp/2018/08/28/levenshtein_hangle/
+    /// - Parameters:
+    ///   - s1: 첫 번째 문자열
+    ///   - s2: 두 번째 문자열
+    /// - Returns: 두 문자열 간의 편집 거리
+    private func levenshteinDistance(from s1: String, to s2: String) -> Int {
+        let s1 = Array(s1)
+        let s2 = Array(s2)
+        let m = s1.count
+        let n = s2.count
+        
+        if m == 0 { return n }
+        if n == 0 { return m }
+        
+        var distanceMatrix = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
+        for i in 0...m {
+            distanceMatrix[i][0] = i
+        }
+        for j in 0...n {
+            distanceMatrix[0][j] = j
+        }
+        
+        for i in 1...m {
+            for j in 1...n {
+                let cost = (s1[i - 1] == s2[j - 1]) ? 0 : 1
+                distanceMatrix[i][j] = min(
+                    distanceMatrix[i - 1][j] + 1,
+                    distanceMatrix[i][j - 1] + 1,
+                    distanceMatrix[i - 1][j - 1] + cost
+                )
+            }
+        }
+        
+        return distanceMatrix[m][n]
+    }
+    
 }


### PR DESCRIPTION
## Issue: #2 TODO : 다양한 Sort 모드 추가

```swift
/// 정렬 모드
/// - hangulOrder: 항목들을 한글 자모 순서대로 정렬.
/// - hangulOrderReversed: 항목들을 한글 자모 역순으로 정렬
/// - editDistance: 검색어와 항목 간의 편집 거리(레벤슈타인 거리)를 기준으로 항목을 정렬. 이 모드는
///   검색어와 가장 유사한 항목을 우선적으로 보여주어 사용자가 관련성 높은 결과를 빠르게 인지할 수 있도록 합니다.
/// - none: 정렬을 수행하지 않습니다.
    
public enum SortMode {
    case hangulOrder
    case hangulOrderReversed
    case editDistance
    case none
}

```
