### PR TITLE
Feat/옵션기반검색확장용공개타입추가(HangulSearchOptions, Hit, MatchKind)

### DIFF
--- a/Sources/HangulSearch/Source/Model/HangulMatchKind.swift
+++ b/Sources/HangulSearch/Source/Model/HangulMatchKind.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum HangulMatchKind: Hashable {
+    case fullMatch
+    case chosungMatch
+    case autocompleteMatch
+}

--- a/Sources/HangulSearch/Source/Model/HangulSearchHit.swift
+++ b/Sources/HangulSearch/Source/Model/HangulSearchHit.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public struct HangulSearchHit<Item> {
+    public let item: Item
+    public let matchKinds: Set<HangulMatchKind>
+    public let matchPosition: Int?
+    public let editDistance: Int?
+    
+    public init(
+        item: Item,
+        matchKinds: Set<HangulMatchKind>,
+        matchPosition: Int? = nil,
+        editDistance: Int? = nil
+    ) {
+        self.item = item
+        self.matchKinds = matchKinds
+        self.matchPosition = matchPosition
+        self.editDistance = editDistance
+    }
+}

--- a/Sources/HangulSearch/Source/Model/HangulSearchOptions.swift
+++ b/Sources/HangulSearch/Source/Model/HangulSearchOptions.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct HangulSearchOptions: Hashable {
+    public enum EmptyQueryBehavior: Hashable {
+        case returnEmpty
+        case returnAll
+    }
+    
+    public var mode: HangulSearchMode?
+    public var sortMode: SortMode?
+    public var limit: Int?
+    public var offset: Int
+    public var minInputLength: Int
+    public var normalizeToNFC: Bool
+    public var emptyQueryBehavior: EmptyQueryBehavior
+    
+    public init(
+        mode: HangulSearchMode? = nil,
+        sortMode: SortMode? = nil,
+        limit: Int? = nil,
+        offset: Int = 0,
+        minInputLength: Int = 1,
+        normalizeToNFC: Bool = false,
+        emptyQueryBehavior: EmptyQueryBehavior = .returnEmpty
+    ) {
+        self.mode = mode
+        self.sortMode = sortMode
+        self.limit = limit
+        self.offset = offset
+        self.minInputLength = minInputLength
+        self.normalizeToNFC = normalizeToNFC
+        self.emptyQueryBehavior = emptyQueryBehavior
+    }
+}

--- a/Tests/HangulSearchTests/HangulSearchPublicTypesTests.swift
+++ b/Tests/HangulSearchTests/HangulSearchPublicTypesTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import HangulSearch
+
+final class HangulSearchPublicTypesTests: XCTestCase {
+    func testHangulSearchOptionsDefaultsMatchLegacyFriendlyValues() {
+        let options = HangulSearchOptions()
+        
+        XCTAssertNil(options.mode)
+        XCTAssertNil(options.sortMode)
+        XCTAssertNil(options.limit)
+        XCTAssertEqual(options.offset, 0)
+        XCTAssertEqual(options.minInputLength, 1)
+        XCTAssertFalse(options.normalizeToNFC)
+        XCTAssertEqual(options.emptyQueryBehavior, .returnEmpty)
+    }
+    
+    func testHangulSearchOptionsStoresCustomValues() {
+        let options = HangulSearchOptions(
+            mode: .combined,
+            sortMode: .editDistance,
+            limit: 25,
+            offset: 5,
+            minInputLength: 2,
+            normalizeToNFC: true,
+            emptyQueryBehavior: .returnAll
+        )
+        
+        XCTAssertEqual(options.mode, .combined)
+        XCTAssertEqual(options.sortMode, .editDistance)
+        XCTAssertEqual(options.limit, 25)
+        XCTAssertEqual(options.offset, 5)
+        XCTAssertEqual(options.minInputLength, 2)
+        XCTAssertTrue(options.normalizeToNFC)
+        XCTAssertEqual(options.emptyQueryBehavior, .returnAll)
+    }
+    
+    func testHangulSearchHitStoresMatchMetadata() {
+        let sampleItem = Person(name: "홍길동", age: 30)
+        let hit = HangulSearchHit(
+            item: sampleItem,
+            matchKinds: [.fullMatch, .autocompleteMatch],
+            matchPosition: 1,
+            editDistance: 2
+        )
+        
+        XCTAssertEqual(hit.item.name, "홍길동")
+        XCTAssertEqual(hit.item.age, 30)
+        XCTAssertEqual(hit.matchKinds, [.fullMatch, .autocompleteMatch])
+        XCTAssertEqual(hit.matchPosition, 1)
+        XCTAssertEqual(hit.editDistance, 2)
+    }
+}

--- a/Tests/HangulSearchTests/HangulSearchPublicTypesTests.swift
+++ b/Tests/HangulSearchTests/HangulSearchPublicTypesTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import HangulSearch
+import HangulSearch
 
 final class HangulSearchPublicTypesTests: XCTestCase {
     func testHangulSearchOptionsDefaultsMatchLegacyFriendlyValues() {


### PR DESCRIPTION
## Description of the Change

옵션 기반 검색 API 확장을 위한 공개 타입을 Additive 방식으로 추가했습니다.

- `HangulSearchOptions` 추가
  - `mode`, `sortMode`, `limit`, `offset`, `minInputLength`, `normalizeToNFC`, `emptyQueryBehavior` 포함
  - 기본값은 기존 1.x 동작을 유지하도록 설정
- `HangulMatchKind` 추가
  - `fullMatch`, `chosungMatch`, `autocompleteMatch`
- `HangulSearchHit<Item>` 추가
  - `item`, `matchKinds`, `matchPosition`, `editDistance`를 담는 상세 결과 타입
- 공개 타입 계약 테스트 추가 (`HangulSearchPublicTypesTests`)
  - 기본값 검증
  - 커스텀 값 저장 검증
  - `HangulSearchHit` 메타데이터 저장 검증

## Motivation

- v1.1.0 Additive 기능(`searchItems(input:options:)`, `searchHits`) 도입 전 타입 계약을 먼저 고정
- 기존 API/기본 동작을 유지한 채 확장 가능한 기초 타입을 선반영
- 이후 단계에서 발생할 회귀를 타입 단위에서 조기 차단

## 핵심 변경 코드

```swift
public struct HangulSearchOptions: Hashable {
    public enum EmptyQueryBehavior: Hashable {
        case returnEmpty
        case returnAll
    }

    public var mode: HangulSearchMode?
    public var sortMode: SortMode?
    public var limit: Int?
    public var offset: Int
    public var minInputLength: Int
    public var normalizeToNFC: Bool
    public var emptyQueryBehavior: EmptyQueryBehavior
}
```

```swift
public struct HangulSearchHit<Item> {
    public let item: Item
    public let matchKinds: Set<HangulMatchKind>
    public let matchPosition: Int?
    public let editDistance: Int?
}
```

## Test

- `swift test --parallel`
- 결과: `22 tests, 0 failures`
