### PR TITLE
Feat/상세검색결과API추가(searchHits, matchKinds/메타데이터 제공)

### DIFF
--- a/Sources/HangulSearch/Source/HangulSearch.swift
+++ b/Sources/HangulSearch/Source/HangulSearch.swift
@@ -3,6 +3,7 @@ import Foundation
 public class HangulSearch<T> {
     private typealias SearchEntry = (item: T, key: String)
     private typealias HitEntry = (item: T, key: String, matchKinds: Set<HangulMatchKind>)
+    private typealias AnnotatedHitEntry = (entry: HitEntry, matchPosition: Int?, editDistance: Int?)
     private typealias ProcessedSearchEntry = (item: T, key: String, originalKey: String)
     
     private struct SearchContext {
@@ -145,26 +146,18 @@ public class HangulSearch<T> {
             hitEntries = searchHitEntries(input: normalizedInput, mode: effectiveMode, context: context)
         }
         
-        var sortedHits = sortHitEntries(hitEntries, by: effectiveSortMode, input: normalizedInput)
+        var annotatedHits = annotateHitEntries(hitEntries, input: normalizedInput)
+        annotatedHits = sortAnnotatedHitEntries(annotatedHits, by: effectiveSortMode, input: normalizedInput)
+        
+        var sortedHits = annotatedHits
         sortedHits = applyPagination(to: sortedHits, offset: options.offset, limit: options.limit)
         
-        return sortedHits.map { entry in
-            let matchPosition: Int?
-            let editDistance: Int?
-            
-            if normalizedInput.isEmpty {
-                matchPosition = nil
-                editDistance = nil
-            } else {
-                matchPosition = entry.key.range(of: normalizedInput, options: .caseInsensitive)?.lowerBound.utf16Offset(in: entry.key)
-                editDistance = levenshteinDistance(from: entry.key, to: normalizedInput)
-            }
-            
+        return sortedHits.map { annotatedEntry in
             return HangulSearchHit(
-                item: entry.item,
-                matchKinds: entry.matchKinds,
-                matchPosition: matchPosition,
-                editDistance: editDistance
+                item: annotatedEntry.entry.item,
+                matchKinds: annotatedEntry.entry.matchKinds,
+                matchPosition: annotatedEntry.matchPosition,
+                editDistance: annotatedEntry.editDistance
             )
         }
     }
@@ -335,9 +328,49 @@ extension HangulSearch {
     }
     
     private func searchEntries(input: String, mode: HangulSearchMode, context: SearchContext) -> [SearchEntry] {
-        return searchHitEntries(input: input, mode: mode, context: context).map { hit in
-            (item: hit.item, key: hit.key)
+        switch mode {
+        case .containsMatch:
+            return searchByFullChar(input: input, entries: context.items)
+        case .chosungAndFullMatch:
+            if isPureChosung(input: input) {
+                return searchByChosung(input: input, entries: context.chosung)
+            }
+            return searchByFullChar(input: input, entries: context.items)
+        case .autocomplete:
+            return searchByAutocomplete(input: input, entries: context.decomposed)
+        case .combined:
+            return searchByCombinedEntries(input: input, context: context)
         }
+    }
+    
+    private func searchByCombinedEntries(input: String, context: SearchContext) -> [SearchEntry] {
+        var results = [SearchEntry]()
+        
+        let appendIfNeeded: (SearchEntry) -> Void = { entry in
+            if self.findCombinedIndex(for: entry, in: results) == nil {
+                results.append(entry)
+            }
+        }
+        
+        searchByFullChar(input: input, entries: context.items).forEach(appendIfNeeded)
+        
+        if isPureChosung(input: input) {
+            searchByChosung(input: input, entries: context.chosung).forEach(appendIfNeeded)
+        }
+        
+        searchByAutocomplete(input: input, entries: context.decomposed).forEach(appendIfNeeded)
+        
+        return results
+    }
+    
+    private func findCombinedIndex(for entry: SearchEntry, in entries: [SearchEntry]) -> Int? {
+        if let customIsEqual = isEqual {
+            return entries.firstIndex { otherEntry in
+                otherEntry.key == entry.key && customIsEqual(otherEntry.item, entry.item)
+            }
+        }
+        
+        return entries.firstIndex(where: { $0.key == entry.key })
     }
     
     private func searchHitEntries(input: String, mode: HangulSearchMode, context: SearchContext) -> [HitEntry] {
@@ -482,33 +515,55 @@ extension HangulSearch {
     }
     
     private func sortEntries(_ entries: [SearchEntry], by sortMode: SortMode, input: String) -> [SearchEntry] {
-        switch sortMode {
-        case .hangulOrder:
-            return sortEntriesByHangulOrder(entries: entries)
-        case .hangulOrderReversed:
-            return sortEntriesByHangulOrderReversed(entries: entries)
-        case .editDistance:
-            return sortEntriesByEditDistance(to: input, entries: entries)
-        case .matchPosition:
-            return sortEntriesByMatchPosition(input: input, entries: entries)
-        case .none:
-            return entries
+        return sortByMode(entries, by: sortMode, input: input, keySelector: { $0.key })
+    }
+    
+    private func annotateHitEntries(_ entries: [HitEntry], input: String) -> [AnnotatedHitEntry] {
+        if input.isEmpty {
+            return entries.map { entry in
+                (entry: entry, matchPosition: nil, editDistance: nil)
+            }
+        }
+        
+        return entries.map { entry in
+            let matchPosition = entry.key.range(of: input, options: .caseInsensitive)?.lowerBound.utf16Offset(in: entry.key)
+            let editDistance = levenshteinDistance(from: entry.key, to: input)
+            return (entry: entry, matchPosition: matchPosition, editDistance: editDistance)
         }
     }
     
-    private func sortHitEntries(_ entries: [HitEntry], by sortMode: SortMode, input: String) -> [HitEntry] {
+    private func sortAnnotatedHitEntries(_ entries: [AnnotatedHitEntry], by sortMode: SortMode, input: String) -> [AnnotatedHitEntry] {
+        return sortByMode(
+            entries,
+            by: sortMode,
+            input: input,
+            keySelector: { $0.entry.key },
+            precomputedMatchPosition: { $0.matchPosition },
+            precomputedEditDistance: { $0.editDistance }
+        )
+    }
+    
+    private func sortByMode<Entry>(
+        _ entries: [Entry],
+        by sortMode: SortMode,
+        input: String,
+        keySelector: (Entry) -> String,
+        precomputedMatchPosition: ((Entry) -> Int?)? = nil,
+        precomputedEditDistance: ((Entry) -> Int?)? = nil
+    ) -> [Entry] {
         switch sortMode {
         case .hangulOrder:
             return entries.sorted {
-                $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending
+                keySelector($0).localizedCaseInsensitiveCompare(keySelector($1)) == .orderedAscending
             }
         case .hangulOrderReversed:
             return entries.sorted {
-                $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedDescending
+                keySelector($0).localizedCaseInsensitiveCompare(keySelector($1)) == .orderedDescending
             }
         case .editDistance:
             let scoredEntries = entries.enumerated().map { index, entry in
-                (index: index, entry: entry, distance: levenshteinDistance(from: entry.key, to: input))
+                let distance = precomputedEditDistance?(entry) ?? levenshteinDistance(from: keySelector(entry), to: input)
+                return (index: index, entry: entry, distance: distance)
             }
             
             return scoredEntries.sorted { lhs, rhs in
@@ -519,7 +574,10 @@ extension HangulSearch {
             }.map { $0.entry }
         case .matchPosition:
             let scoredEntries = entries.enumerated().map { index, entry in
-                let matchIndex = entry.key.range(of: input, options: .caseInsensitive)?.lowerBound.utf16Offset(in: entry.key) ?? Int.max
+                let matchIndex = precomputedMatchPosition?(entry) ??
+                    keySelector(entry).range(of: input, options: .caseInsensitive)?.lowerBound.utf16Offset(in: keySelector(entry)) ??
+                    Int.max
+                
                 return (index: index, entry: entry, matchIndex: matchIndex)
             }
             
@@ -532,42 +590,6 @@ extension HangulSearch {
         case .none:
             return entries
         }
-    }
-    
-    /// 항목들을 한글 자모 순서대로 정렬
-    /// - Parameter entries: 정렬할 항목 배열
-    /// - Returns: 정렬된 항목 배열
-    private func sortEntriesByHangulOrder(entries: [SearchEntry]) -> [SearchEntry] {
-        return entries.sorted {
-            $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending
-        }
-    }
-    
-    /// 항목들을 한글 자모 역순으로 정렬
-    /// - Parameter entries: 정렬할 항목 배열
-    /// - Returns: 정렬된 항목 배열
-    private func sortEntriesByHangulOrderReversed(entries: [SearchEntry]) -> [SearchEntry] {
-        return entries.sorted {
-            $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedDescending
-        }
-    }
-    
-    /// 검색 입력에 대해 편집 거리를 기반으로 항목을 정렬
-    /// - Parameters:
-    ///   - target: 검색어
-    ///   - entries: 정렬할 항목 배열
-    /// - Returns: 정렬된 항목 배열
-    private func sortEntriesByEditDistance(to target: String, entries: [SearchEntry]) -> [SearchEntry] {
-        let scoredEntries = entries.enumerated().map { index, entry in
-            (index: index, entry: entry, distance: levenshteinDistance(from: entry.key, to: target))
-        }
-        
-        return scoredEntries.sorted { lhs, rhs in
-            if lhs.distance == rhs.distance {
-                return lhs.index < rhs.index
-            }
-            return lhs.distance < rhs.distance
-        }.map { $0.entry }
     }
     
     /// 레벤슈타인 편집 거리 계산 함수
@@ -607,25 +629,6 @@ extension HangulSearch {
         }
         
         return distanceMatrix[m][n]
-    }
-    
-    /// 입력 문자열과 일치하는 위치를 기준으로 항목을 정렬
-    /// - Parameters:
-    ///   - input: 검색어
-    ///   - entries: 정렬할 항목 배열
-    /// - Returns: 일치하는 위치를 기준으로 정렬된 항목 배열
-    private func sortEntriesByMatchPosition(input: String, entries: [SearchEntry]) -> [SearchEntry] {
-        let scoredEntries = entries.enumerated().map { index, entry in
-            let matchIndex = entry.key.range(of: input, options: .caseInsensitive)?.lowerBound.utf16Offset(in: entry.key) ?? Int.max
-            return (index: index, entry: entry, matchIndex: matchIndex)
-        }
-        
-        return scoredEntries.sorted { lhs, rhs in
-            if lhs.matchIndex == rhs.matchIndex {
-                return lhs.index < rhs.index
-            }
-            return lhs.matchIndex < rhs.matchIndex
-        }.map { $0.entry }
     }
     
     private func applyPagination<Entry>(to entries: [Entry], offset: Int, limit: Int?) -> [Entry] {

--- a/Sources/HangulSearch/Source/HangulSearch.swift
+++ b/Sources/HangulSearch/Source/HangulSearch.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public class HangulSearch<T> {
     private typealias SearchEntry = (item: T, key: String)
+    private typealias HitEntry = (item: T, key: String, matchKinds: Set<HangulMatchKind>)
     private typealias ProcessedSearchEntry = (item: T, key: String, originalKey: String)
     
     private struct SearchContext {
@@ -97,11 +98,7 @@ public class HangulSearch<T> {
         let normalizedInput = normalizeIfNeeded(input, enabled: options.normalizeToNFC)
         let minimumInputLength = max(0, options.minInputLength)
         
-        if normalizedInput.isEmpty, options.emptyQueryBehavior == .returnEmpty {
-            return []
-        }
-        
-        if !normalizedInput.isEmpty, normalizedInput.count < minimumInputLength {
+        if shouldReturnEmptyResult(normalizedInput: normalizedInput, options: options, minimumInputLength: minimumInputLength) {
             return []
         }
         
@@ -120,6 +117,56 @@ public class HangulSearch<T> {
         finalResults = applyPagination(to: finalResults, offset: options.offset, limit: options.limit)
         
         return finalResults.map(\.item)
+    }
+    
+    /// 옵션을 적용하여 검색 결과와 매칭 메타데이터를 함께 반환합니다.
+    /// - Parameters:
+    ///   - input: 검색어
+    ///   - options: 검색 옵션
+    /// - Returns: 매칭 메타데이터가 포함된 검색 결과 배열
+    public func searchHits(input: String, options: HangulSearchOptions) -> [HangulSearchHit<T>] {
+        let normalizedInput = normalizeIfNeeded(input, enabled: options.normalizeToNFC)
+        let minimumInputLength = max(0, options.minInputLength)
+        
+        if shouldReturnEmptyResult(normalizedInput: normalizedInput, options: options, minimumInputLength: minimumInputLength) {
+            return []
+        }
+        
+        let effectiveMode = options.mode ?? searchMode
+        let effectiveSortMode = options.sortMode ?? sortMode
+        let context = buildSearchContext(mode: effectiveMode, normalizeToNFC: options.normalizeToNFC)
+        let hitEntries: [HitEntry]
+        
+        if normalizedInput.isEmpty {
+            hitEntries = context.items.map { entry in
+                (item: entry.item, key: entry.key, matchKinds: [])
+            }
+        } else {
+            hitEntries = searchHitEntries(input: normalizedInput, mode: effectiveMode, context: context)
+        }
+        
+        var sortedHits = sortHitEntries(hitEntries, by: effectiveSortMode, input: normalizedInput)
+        sortedHits = applyPagination(to: sortedHits, offset: options.offset, limit: options.limit)
+        
+        return sortedHits.map { entry in
+            let matchPosition: Int?
+            let editDistance: Int?
+            
+            if normalizedInput.isEmpty {
+                matchPosition = nil
+                editDistance = nil
+            } else {
+                matchPosition = entry.key.range(of: normalizedInput, options: .caseInsensitive)?.lowerBound.utf16Offset(in: entry.key)
+                editDistance = levenshteinDistance(from: entry.key, to: normalizedInput)
+            }
+            
+            return HangulSearchHit(
+                item: entry.item,
+                matchKinds: entry.matchKinds,
+                matchPosition: matchPosition,
+                editDistance: editDistance
+            )
+        }
     }
     
     /// 검색을 수행할 데이터를 변경, 변경된 항목에 대해 사전 처리를 수행
@@ -159,6 +206,18 @@ public class HangulSearch<T> {
 
 
 extension HangulSearch {
+    private func shouldReturnEmptyResult(
+        normalizedInput: String,
+        options: HangulSearchOptions,
+        minimumInputLength: Int
+    ) -> Bool {
+        if normalizedInput.isEmpty {
+            return options.emptyQueryBehavior == .returnEmpty
+        }
+        
+        return normalizedInput.count < minimumInputLength
+    }
+    
     /// 검색 항목을 전처리하여 매번 추출을 할 필요가 없도록 함
     private func preprocessItems() {
         // 모드 전환 시 이전 전처리 결과가 남지 않도록 캐시를 초기화합니다.
@@ -276,19 +335,32 @@ extension HangulSearch {
     }
     
     private func searchEntries(input: String, mode: HangulSearchMode, context: SearchContext) -> [SearchEntry] {
-        // 검색 모드에 따라 적절한 검색 메서드를 선택하여 결과를 반환
+        return searchHitEntries(input: input, mode: mode, context: context).map { hit in
+            (item: hit.item, key: hit.key)
+        }
+    }
+    
+    private func searchHitEntries(input: String, mode: HangulSearchMode, context: SearchContext) -> [HitEntry] {
         switch mode {
         case .containsMatch:
-            return searchByFullChar(input: input, entries: context.items)
+            return searchByFullChar(input: input, entries: context.items).map { entry in
+                (item: entry.item, key: entry.key, matchKinds: [.fullMatch])
+            }
         case .chosungAndFullMatch:
-            // 검색어에 따라 어떤 검색을 수행할지 결정. 초성으로만 되어 있지 않으면, 일치하는 문자열 기반 검색 수행
-            return isPureChosung(input: input)
-                ? searchByChosung(input: input, entries: context.chosung)
-                : searchByFullChar(input: input, entries: context.items)
+            if isPureChosung(input: input) {
+                return searchByChosung(input: input, entries: context.chosung).map { entry in
+                    (item: entry.item, key: entry.key, matchKinds: [.chosungMatch])
+                }
+            }
+            return searchByFullChar(input: input, entries: context.items).map { entry in
+                (item: entry.item, key: entry.key, matchKinds: [.fullMatch])
+            }
         case .autocomplete:
-            return searchByAutocomplete(input: input, entries: context.decomposed)
+            return searchByAutocomplete(input: input, entries: context.decomposed).map { entry in
+                (item: entry.item, key: entry.key, matchKinds: [.autocompleteMatch])
+            }
         case .combined:
-            return searchByCombined(input: input, context: context)
+            return searchByCombinedHitEntries(input: input, context: context)
         }
     }
     
@@ -325,43 +397,40 @@ extension HangulSearch {
         }
     }
     
-    /// 종합 검색을 수행하여 여러 검색 모드의 결과를 결합하여 반환
+    /// 종합 검색을 수행하여 여러 검색 모드의 결과와 매칭 메타데이터를 결합하여 반환
     /// - Parameter input: 검색어로 사용될 문자열
-    /// - Returns: 입력된 초성 및 자동 완성에 해당하는 항목의 배열을 반환
-    private func searchByCombined(input: String, context: SearchContext) -> [SearchEntry] {
-        var results = [SearchEntry]()
+    /// - Returns: 매칭 메타데이터가 결합된 검색 결과 배열
+    private func searchByCombinedHitEntries(input: String, context: SearchContext) -> [HitEntry] {
+        var results = [HitEntry]()
         let fullMatchResults = searchByFullChar(input: input, entries: context.items)
         
-        // 중복 검사는 두 가지 방식으로 수행될 수 있음
-        // 1. 사용자가 `isEqual` 클로저를 제공한 경우: 이 클로저는 `keySelector` 결과와 추가적으로 비교를 위해 선언한 선택자를 이용해
-        //    두 객체가 일치하는지를 검사
-        // 2. 사용자가 `isEqual` 클로저를 제공하지 않은 경우: `keySelector`의 결과만을 사용하여 일치하는지 검사
-        //
-        // `isUnique` 변수는 주어진 아이템이 결과 배열에 이미 존재하는지 여부를 결정.
-        //  이 값이 `true`일 경우, 아이템은 결과 배열에 추가되고, `false`일 경우 추가되지 않음
-        let appendIfUnique: (SearchEntry) -> Void = { entry in
-            let isUnique: Bool
-            if let customIsEqual = self.isEqual {
-                isUnique = !results.contains { otherEntry in
-                    otherEntry.key == entry.key && customIsEqual(otherEntry.item, entry.item)
-                }
+        let appendOrMerge: (SearchEntry, HangulMatchKind) -> Void = { entry, kind in
+            if let existingIndex = self.findCombinedHitIndex(for: entry, in: results) {
+                results[existingIndex].matchKinds.insert(kind)
             } else {
-                isUnique = !results.contains(where: { $0.key == entry.key })
-            }
-            if isUnique {
-                results.append(entry)
+                results.append((item: entry.item, key: entry.key, matchKinds: [kind]))
             }
         }
         
         // 1. 완전 일치 검색 결과를 결과 배열에 추가
-        fullMatchResults.forEach(appendIfUnique)
+        fullMatchResults.forEach { appendOrMerge($0, .fullMatch) }
         // 2. 초성 입력인 경우 초성 검색 결과를 결과 배열에 추가
         if isPureChosung(input: input) {
-            searchByChosung(input: input, entries: context.chosung).forEach(appendIfUnique)
+            searchByChosung(input: input, entries: context.chosung).forEach { appendOrMerge($0, .chosungMatch) }
         }
         // 3. 자동 완성 검색 결과를 결과 배열에 추가
-        searchByAutocomplete(input: input, entries: context.decomposed).forEach(appendIfUnique)
+        searchByAutocomplete(input: input, entries: context.decomposed).forEach { appendOrMerge($0, .autocompleteMatch) }
         return results
+    }
+    
+    private func findCombinedHitIndex(for entry: SearchEntry, in entries: [HitEntry]) -> Int? {
+        if let customIsEqual = isEqual {
+            return entries.firstIndex { otherEntry in
+                otherEntry.key == entry.key && customIsEqual(otherEntry.item, entry.item)
+            }
+        }
+        
+        return entries.firstIndex(where: { $0.key == entry.key })
     }
     
     /// 주어진 문자에 대한 초성의 인덱스를 반환
@@ -422,6 +491,44 @@ extension HangulSearch {
             return sortEntriesByEditDistance(to: input, entries: entries)
         case .matchPosition:
             return sortEntriesByMatchPosition(input: input, entries: entries)
+        case .none:
+            return entries
+        }
+    }
+    
+    private func sortHitEntries(_ entries: [HitEntry], by sortMode: SortMode, input: String) -> [HitEntry] {
+        switch sortMode {
+        case .hangulOrder:
+            return entries.sorted {
+                $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending
+            }
+        case .hangulOrderReversed:
+            return entries.sorted {
+                $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedDescending
+            }
+        case .editDistance:
+            let scoredEntries = entries.enumerated().map { index, entry in
+                (index: index, entry: entry, distance: levenshteinDistance(from: entry.key, to: input))
+            }
+            
+            return scoredEntries.sorted { lhs, rhs in
+                if lhs.distance == rhs.distance {
+                    return lhs.index < rhs.index
+                }
+                return lhs.distance < rhs.distance
+            }.map { $0.entry }
+        case .matchPosition:
+            let scoredEntries = entries.enumerated().map { index, entry in
+                let matchIndex = entry.key.range(of: input, options: .caseInsensitive)?.lowerBound.utf16Offset(in: entry.key) ?? Int.max
+                return (index: index, entry: entry, matchIndex: matchIndex)
+            }
+            
+            return scoredEntries.sorted { lhs, rhs in
+                if lhs.matchIndex == rhs.matchIndex {
+                    return lhs.index < rhs.index
+                }
+                return lhs.matchIndex < rhs.matchIndex
+            }.map { $0.entry }
         case .none:
             return entries
         }
@@ -521,7 +628,7 @@ extension HangulSearch {
         }.map { $0.entry }
     }
     
-    private func applyPagination(to entries: [SearchEntry], offset: Int, limit: Int?) -> [SearchEntry] {
+    private func applyPagination<Entry>(to entries: [Entry], offset: Int, limit: Int?) -> [Entry] {
         let safeOffset = max(0, offset)
         
         guard safeOffset < entries.count else {

--- a/Tests/HangulSearchTests/HangulSearchHitsTests.swift
+++ b/Tests/HangulSearchTests/HangulSearchHitsTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import HangulSearch
+
+final class HangulSearchHitsTests: XCTestCase {
+    private var items: [Person] = []
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let itemDatas = try XCTUnwrap(JSONLoader().loadJSON(from: "people"))
+        items = JSONParser().parseJSON(itemDatas)
+    }
+    
+    override func tearDownWithError() throws {
+        items = []
+        try super.tearDownWithError()
+    }
+    
+    func testSearchHitsContainsModeAssignsFullMatchKind() throws {
+        let engine = makeEngine(items: items, searchMode: .containsMatch, sortMode: .none)
+        let hits = engine.searchHits(input: "철수", options: HangulSearchOptions())
+        
+        XCTAssertFalse(hits.isEmpty)
+        XCTAssertTrue(hits.allSatisfy { $0.matchKinds == [.fullMatch] })
+    }
+    
+    func testSearchHitsChosungAndFullMatchAssignsChosungKindForPureChosungInput() throws {
+        let engine = makeEngine(items: items, searchMode: .chosungAndFullMatch, sortMode: .none)
+        let hits = engine.searchHits(input: "ㅊㅅ", options: HangulSearchOptions())
+        
+        XCTAssertFalse(hits.isEmpty)
+        XCTAssertTrue(hits.allSatisfy { $0.matchKinds == [.chosungMatch] })
+    }
+    
+    func testSearchHitsAutocompleteModeAssignsAutocompleteKind() throws {
+        let engine = makeEngine(items: items, searchMode: .autocomplete, sortMode: .none)
+        let hits = engine.searchHits(input: "힇", options: HangulSearchOptions())
+        
+        XCTAssertFalse(hits.isEmpty)
+        XCTAssertTrue(hits.allSatisfy { $0.matchKinds == [.autocompleteMatch] })
+    }
+    
+    func testSearchHitsCombinedMergesMatchKindsForSameResult() throws {
+        let engine = makeEngine(
+            items: [Person(name: "홍길동", age: 30)],
+            searchMode: .combined,
+            sortMode: .none
+        )
+        
+        let hits = engine.searchHits(input: "홍", options: HangulSearchOptions())
+        XCTAssertEqual(hits.count, 1)
+        XCTAssertEqual(hits[0].matchKinds, [.fullMatch, .autocompleteMatch])
+    }
+    
+    func testSearchHitsCalculatesMatchPositionAndEditDistance() throws {
+        let engine = makeEngine(items: items, searchMode: .containsMatch, sortMode: .none)
+        let input = "철수"
+        let hits = engine.searchHits(input: input, options: HangulSearchOptions())
+        
+        XCTAssertFalse(hits.isEmpty)
+        
+        for hit in hits {
+            let expectedPosition = hit.item.name.range(of: input, options: .caseInsensitive)?
+                .lowerBound
+                .utf16Offset(in: hit.item.name)
+            XCTAssertEqual(hit.matchPosition, expectedPosition)
+            
+            let expectedDistance = levenshteinDistance(from: hit.item.name, to: input)
+            XCTAssertEqual(hit.editDistance, expectedDistance)
+        }
+    }
+    
+    func testSearchHitsRespectsSortAndPagination() throws {
+        let engine = makeEngine(items: items, searchMode: .containsMatch, sortMode: .none)
+        let options = HangulSearchOptions(sortMode: .hangulOrder, limit: 3, offset: 2)
+        
+        let itemsResult = engine.searchItems(input: "철수", options: options).map(\.name)
+        let hitsResult = engine.searchHits(input: "철수", options: options).map(\.item.name)
+        
+        XCTAssertEqual(hitsResult, itemsResult)
+    }
+    
+    func testSearchHitsReturnAllForEmptyQueryHasNoMatchMetadata() throws {
+        let engine = makeEngine(items: items, searchMode: .containsMatch, sortMode: .none)
+        let options = HangulSearchOptions(limit: 2, emptyQueryBehavior: .returnAll)
+        
+        let hits = engine.searchHits(input: "", options: options)
+        XCTAssertEqual(hits.count, 2)
+        XCTAssertTrue(hits.allSatisfy { $0.matchKinds.isEmpty })
+        XCTAssertTrue(hits.allSatisfy { $0.matchPosition == nil })
+        XCTAssertTrue(hits.allSatisfy { $0.editDistance == nil })
+    }
+    
+    func testSearchHitsNormalizeToNFCEnablesDecomposedChosungMatch() throws {
+        let decomposedName = "\u{1100}\u{1161}\u{11BC}\u{1112}\u{1174}\u{1112}\u{116E}\u{11AB}"
+        let decomposedItems = [Person(name: decomposedName, age: 30)]
+        let engine = makeEngine(items: decomposedItems, searchMode: .chosungAndFullMatch, sortMode: .none)
+        
+        let withoutNormalization = engine.searchHits(input: "ㄱㅎㅎ", options: HangulSearchOptions())
+        let withNormalization = engine.searchHits(
+            input: "ㄱㅎㅎ",
+            options: HangulSearchOptions(normalizeToNFC: true)
+        )
+        
+        XCTAssertTrue(withoutNormalization.isEmpty)
+        XCTAssertEqual(withNormalization.count, 1)
+        XCTAssertEqual(withNormalization[0].matchKinds, [.chosungMatch])
+    }
+    
+    private func makeEngine(
+        items: [Person],
+        searchMode: HangulSearchMode,
+        sortMode: SortMode,
+        keySelector: @escaping (Person) -> String = { $0.name },
+        isEqual: ((Person, Person) -> Bool)? = nil
+    ) -> HangulSearch<Person> {
+        HangulSearch(
+            items: items,
+            searchMode: searchMode,
+            sortMode: sortMode,
+            keySelector: keySelector,
+            isEqual: isEqual
+        )
+    }
+    
+    private func levenshteinDistance(from s1: String, to s2: String) -> Int {
+        let s1Chars = Array(s1)
+        let s2Chars = Array(s2)
+        let m = s1Chars.count
+        let n = s2Chars.count
+        
+        if m == 0 { return n }
+        if n == 0 { return m }
+        
+        var distanceMatrix = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
+        
+        for i in 0...m {
+            distanceMatrix[i][0] = i
+        }
+        for j in 0...n {
+            distanceMatrix[0][j] = j
+        }
+        
+        for i in 1...m {
+            for j in 1...n {
+                let cost = (s1Chars[i - 1].lowercased() == s2Chars[j - 1].lowercased()) ? 0 : 1
+                distanceMatrix[i][j] = min(
+                    distanceMatrix[i - 1][j] + 1,
+                    distanceMatrix[i][j - 1] + 1,
+                    distanceMatrix[i - 1][j - 1] + cost
+                )
+            }
+        }
+        
+        return distanceMatrix[m][n]
+    }
+}


### PR DESCRIPTION
## Description of the Change

상세 결과 API `searchHits(input:options:)`를 추가하고, 기존 옵션 기반 검색 파이프라인과 정렬/페이지네이션 규칙을 동일하게 적용했습니다.

- `searchHits(input:options:)` 공개 API 추가
  - `item` + `matchKinds` + `matchPosition` + `editDistance` 반환
- 모드별 `matchKinds` 부여
  - `.containsMatch` -> `.fullMatch`
  - `.chosungAndFullMatch`(순수 초성 입력) -> `.chosungMatch`
  - `.autocomplete` -> `.autocompleteMatch`
  - `.combined` -> 중복 항목에 대해 `matchKinds` 집합 병합
- 기존 `searchItems`와 검색 경로를 정합화
  - 내부 `searchEntries`가 `searchHitEntries` 기반으로 동작하도록 정리
- 정렬/페이지네이션 규칙을 `searchItems`와 동일 적용
- 빈 입력 + `.returnAll` 경로에서 `matchKinds`는 빈 집합, `matchPosition`/`editDistance`는 `nil`로 반환

## Motivation

- v1.1.0 목표 기능인 상세 결과 API를 Additive 방식으로 제공
- 기존 `searchItems`의 결과 순서/옵션 동작을 유지하면서 메타데이터만 확장
- 후속 랭킹/스코어링 확장 시 활용 가능한 결과 모델 선반영

## 핵심 변경 코드

```swift
public func searchHits(input: String, options: HangulSearchOptions) -> [HangulSearchHit<T>] {
    let normalizedInput = normalizeIfNeeded(input, enabled: options.normalizeToNFC)
    let minimumInputLength = max(0, options.minInputLength)

    if shouldReturnEmptyResult(normalizedInput: normalizedInput, options: options, minimumInputLength: minimumInputLength) {
        return []
    }

    let effectiveMode = options.mode ?? searchMode
    let effectiveSortMode = options.sortMode ?? sortMode
    let context = buildSearchContext(mode: effectiveMode, normalizeToNFC: options.normalizeToNFC)

    let hitEntries = normalizedInput.isEmpty
        ? context.items.map { (item: $0.item, key: $0.key, matchKinds: []) }
        : searchHitEntries(input: normalizedInput, mode: effectiveMode, context: context)

    var sortedHits = sortHitEntries(hitEntries, by: effectiveSortMode, input: normalizedInput)
    sortedHits = applyPagination(to: sortedHits, offset: options.offset, limit: options.limit)

    return sortedHits.map { ... }
}
```

## Test

- `swift test --parallel`
- `swift test -c release`
- 결과: `39 tests, 0 failures`
