### PR TITLE
Docs/운영체계보강(TSan게이트+릴리즈문서4종+README동기화)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,20 @@ jobs:
       - name: Run Unit Tests (Release)
         run: swift test -c release
 
+  test-tsan:
+    name: Test (Thread Sanitizer)
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Swift Version
+        run: swift --version
+
+      - name: Run Unit Tests (TSan)
+        run: swift test --sanitize=thread
+
   benchmark-smoke:
     name: Benchmark Smoke (Synthetic 10k)
     runs-on: macos-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+Note: The latest released version is `1.0.1` (2026-02-24). Entries in this
+section are pending and may be grouped into the next `1.1.x` / `1.2.x` release
+line at release time.
+
 ### Added
 - CI gate now includes `swift test --parallel`, `swift test -c release`,
   `swift test --sanitize=thread`, and a benchmark smoke test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project follows Semantic Versioning.
+
+## [Unreleased]
+
+### Added
+- CI gate now includes `swift test --parallel`, `swift test -c release`,
+  `swift test --sanitize=thread`, and a benchmark smoke test.
+- Added release operation documents:
+  `MIGRATION.md`, `CONTRIBUTING.md`, and `SECURITY.md`.
+- Added legacy API compatibility regression tests for 1.0.x style usage.
+
+### Changed
+- `combined` mode dedup path now uses key buckets for improved performance.
+- `levenshteinDistance` switched to a 2-row DP implementation to reduce memory usage.
+
+## [1.0.1] - 2026-02-24
+
+### Added
+- Additive public API for options and detailed hits:
+  `HangulSearchOptions`, `HangulSearchHit`, `HangulMatchKind`,
+  `searchItems(input:options:)`, and `searchHits(input:options:)`.
+
+### Changed
+- Internal search pipeline refactoring for deterministic sorting and cache reuse.
+
+## [1.0.0] - 2024-09-09
+
+### Added
+- Initial stable release of HangulSearch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing
+
+Thank you for contributing to HangulSearch.
+
+## Prerequisites
+
+- Swift toolchain compatible with this repository (`swift --version`)
+- macOS environment for parity with CI (`macos-14` runners)
+
+## Development setup
+
+```bash
+git clone https://github.com/Juhwa-Lee1023/HangulSearch.git
+cd HangulSearch
+swift test --parallel
+```
+
+## Branch and commit conventions
+
+- Keep one logical change per PR.
+- Prefer additive changes in 1.x. Do not introduce breaking API changes.
+- Use concise commit titles with a clear prefix, for example:
+  - `Feat/...`
+  - `Fix/...`
+  - `Perf/...`
+  - `Test/...`
+  - `Docs/...`
+
+## Local checks before opening a PR
+
+Run all required checks locally:
+
+```bash
+swift test --parallel
+swift test -c release
+swift test --sanitize=thread
+swift test -c release --filter HangulSearchBenchmarkSmokeTests/testCombinedModeP95SmokeSynthetic10k
+```
+
+## PR checklist
+
+1. Include a clear motivation and behavior impact summary.
+2. Confirm 1.x compatibility (no removed public API, no default behavior break).
+3. Add or update tests for changed behavior.
+4. Update docs when public behavior/contracts changed.
+5. Ensure CI is green.
+
+## Code style notes
+
+- Keep behavior deterministic.
+- Preserve stable tie-break behavior in sorting paths.
+- Prefer reusable internal helpers over duplicated logic.
+- Keep comments focused on non-obvious decisions.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -45,7 +45,7 @@ let hits = engine.searchHits(input: query, options: options)
 
 No breaking API change is planned.
 
-This line focuses on performance and operational hardening:
+This release line focuses on performance and operational hardening:
 
 - internal dedup optimization for combined mode
 - memory optimization for edit-distance calculation

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,61 @@
+# Migration Guide
+
+This guide explains how to migrate between HangulSearch minor versions in 1.x.
+
+## 1.0.x -> 1.1.x
+
+No breaking API change is required.
+
+Existing 1.0.x code keeps working:
+
+```swift
+let results = engine.searchItems(input: query)
+engine.changeItems(items: newItems)
+engine.changeSearchMode(mode: .combined)
+engine.changeSortMode(mode: .matchPosition)
+```
+
+### Optional adoption in 1.1.x
+
+You can adopt additive APIs when needed:
+
+```swift
+let options = HangulSearchOptions(
+    mode: .combined,
+    sortMode: .editDistance,
+    limit: 20,
+    offset: 0,
+    normalizeToNFC: true
+)
+let items = engine.searchItems(input: query, options: options)
+let hits = engine.searchHits(input: query, options: options)
+```
+
+### Behavior notes
+
+- Default empty query behavior remains unchanged:
+  `searchItems(input: "")` returns `[]`.
+- `searchItems(input:options:)` also returns `[]` by default.
+  To return all, use `emptyQueryBehavior: .returnAll`.
+- `normalizeToNFC` is opt-in (`false` by default) to preserve legacy behavior.
+- Sort tie-break for `matchPosition` and `editDistance` remains deterministic
+  using original result order.
+
+## 1.1.x -> 1.2.x
+
+No breaking API change is planned.
+
+This line focuses on performance and operational hardening:
+
+- internal dedup optimization for combined mode
+- memory optimization for edit-distance calculation
+- stronger CI/release process docs and gates
+
+## Upgrade checklist
+
+1. Update package dependency to the target 1.x version.
+2. Run local checks:
+   - `swift test --parallel`
+   - `swift test -c release`
+3. If you use concurrent mutation/search patterns, also run:
+   - `swift test --sanitize=thread`

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ public struct HangulSearchOptions {
 - Pull Request 및 `main`/`codex/**` push에서 아래 잡을 실행합니다.
 - `swift test --parallel`
 - `swift test -c release`
+- `swift test --sanitize=thread`
 - benchmark smoke (`HangulSearchBenchmarkSmokeTests`)
 
 ## 참고 자료
@@ -166,6 +167,12 @@ public struct HangulSearchOptions {
 - [기본 테스트](https://github.com/Juhwa-Lee1023/HangulSearch/blob/main/Tests/HangulSearchTests/HangulSearchTests.swift)
 - [옵션 API 테스트](https://github.com/Juhwa-Lee1023/HangulSearch/blob/main/Tests/HangulSearchTests/HangulSearchOptionsSearchTests.swift)
 - [상세 결과 API 테스트](https://github.com/Juhwa-Lee1023/HangulSearch/blob/main/Tests/HangulSearchTests/HangulSearchHitsTests.swift)
+
+## 운영 문서
+- [CHANGELOG](CHANGELOG.md)
+- [MIGRATION](MIGRATION.md)
+- [CONTRIBUTING](CONTRIBUTING.md)
+- [SECURITY](SECURITY.md)
 
 ## 데모 영상
 - 초성 검색: https://github.com/Juhwa-Lee1023/HangulSearch/assets/63584245/9f5e0f28-d8ab-4010-9b58-79eafb35b798

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,10 @@ Security fixes are provided based on the following policy:
 | 1.0.x | Critical fixes only |
 | < 1.0.0 | Not supported |
 
+Note: At the time of writing, the latest released version is `1.0.1` (see
+`CHANGELOG.md`). The `1.1.x` and `1.2.x` rows are a forward-looking support
+policy for upcoming releases.
+
 ## Reporting a vulnerability
 
 Please do not open a public GitHub issue for security vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided based on the following policy:
+
+| Version | Support status |
+| --- | --- |
+| 1.2.x | Active support |
+| 1.1.x | Active support |
+| 1.0.x | Critical fixes only |
+| < 1.0.0 | Not supported |
+
+## Reporting a vulnerability
+
+Please do not open a public GitHub issue for security vulnerabilities.
+
+Use GitHub private vulnerability reporting:
+
+1. Go to the repository Security tab.
+2. Choose "Report a vulnerability".
+3. Provide reproduction steps, impact scope, and affected versions.
+
+## Response expectations
+
+- Initial triage target: within 5 business days.
+- Status update target: at least once every 7 days while the report is active.
+- Fix and disclosure timeline depends on severity and exploitability.
+
+## Disclosure
+
+After a fix is ready, maintainers may publish a security advisory and release notes.


### PR DESCRIPTION
## Description of the Change

PR-6에서 운영 체계 미완 항목을 정리했습니다.

- CI 게이트 확장
  - 기존: `swift test --parallel`, `swift test -c release`, benchmark smoke
  - 추가: `swift test --sanitize=thread` (Thread Sanitizer)
- 릴리즈/운영 문서 4종 추가
  - `CHANGELOG.md`
  - `MIGRATION.md`
  - `CONTRIBUTING.md`
  - `SECURITY.md`
- README 동기화
  - CI 섹션에 TSan 게이트 반영
  - 운영 문서 섹션/링크 추가

## Motivation

- 계획상 PR-4 잔여 항목(운영 체계 고도화) 완료
- 릴리즈 프로세스와 기여/보안 정책을 저장소 기준 문서로 명문화
- 동시성 이슈를 조기에 감지할 수 있도록 CI에 TSan 게이트 포함

## 핵심 변경 코드

```yaml
jobs:
  test-tsan:
    name: Test (Thread Sanitizer)
    runs-on: macos-14
    steps:
      - run: swift test --sanitize=thread
```

## Test

- `swift test --parallel`
- `swift test -c release`
- `swift test --sanitize=thread`
- 결과: `43 tests, 0 failures`
